### PR TITLE
make body full height in case few boxes are show to prevent white space

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -48,7 +48,7 @@ class App extends Component {
                     </div>
                 </nav>
 
-                <section className="section">
+                <section className="section hero is-fullheight-with-navbar">
                     <div className="columns">
                         <div className="column">
                             <div className="box">


### PR DESCRIPTION
Noticed this as I was building mine up. If theres a tag with little content, the background will end prematurely, leaving a large white space at the bottom of the page. These added classes prevent that.